### PR TITLE
Figure out how much rain we've had since midnight

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -80,6 +80,18 @@
     service: light.turn_off
     entity_id: light.hallway_bathroom_stars
 
+# Push the value of the rain we got yesterday into a retained mqtt topic
+- alias: "Push previous day rain total to MQTT"
+  trigger:
+    - platform: time
+      at: "00:00:01"
+  action:
+    service: mqtt.publish
+    data_template:
+      topic: "internal/rain_in_prior"
+      retain: true
+      payload: "{{ states.sensor.rain_amount.state }}"
+
 ######################################3
 #
 # MQTT Events

--- a/sensors.yaml
+++ b/sensors.yaml
@@ -47,20 +47,21 @@
   icon: mdi:weather-rainy
 ### End MQTT
 
-
 # This allows me to see how much rain has come in today, rather than
 # over the lifetime of the senor
 - platform: mqtt
-  state_topic: 'internal/rain_in_prior'
-  name: 'rain_in_prior'
-  unit_of_measurement: 'in'
+  state_topic: "internal/rain_in_prior"
+  name: "rain_in_prior"
+  unit_of_measurement: "in"
 - platform: template
   sensors:
     rain_today:
-      value_template: '{%- if not (is_state("sensor.rain_amount","unknown") or is_state("sensor.rain_in_prior","unknown") )-%}  {{ ((states.sensor.rain_in.state | float) - (states.sensor.rain_in_prior.state | float)) | max (0) | round(1) }} {%- endif -%}' ## ensure calc is no lower than zero!
-      friendly_name: 'Rain Today'
-      unit_of_measurement: 'in'
-
+      value_template: >
+        {%- if not (is_state("sensor.rain_amount","unknown") or is_state("sensor.rain_in_prior","unknown") )-%}
+        {{ ((states.sensor.rain_amount.state | float) - (states.sensor.rain_in_prior.state | float)) | max (0) | round(1) }}
+        {%- endif -%}'
+      friendly_name: "Rain Today"
+      unit_of_measurement: "in"
 
 # Show the wind in human units
 - platform: template

--- a/sensors.yaml
+++ b/sensors.yaml
@@ -43,10 +43,26 @@
 - platform: mqtt
   name: "Rain Amount"
   state_topic: "weather/Acurite-5n1/rain_in"
-  unit_of_measurement: "inches"
+  unit_of_measurement: "in"
   icon: mdi:weather-rainy
 ### End MQTT
 
+
+# This allows me to see how much rain has come in today, rather than
+# over the lifetime of the senor
+- platform: mqtt
+  state_topic: 'internal/rain_in_prior'
+  name: 'rain_in_prior'
+  unit_of_measurement: 'in'
+- platform: template
+  sensors:
+    rain_today:
+      value_template: '{%- if not (is_state("sensor.rain_amount","unknown") or is_state("sensor.rain_in_prior","unknown") )-%}  {{ ((states.sensor.rain_in.state | float) - (states.sensor.rain_in_prior.state | float)) | max (0) | round(1) }} {%- endif -%}' ## ensure calc is no lower than zero!
+      friendly_name: 'Rain Today'
+      unit_of_measurement: 'in'
+
+
+# Show the wind in human units
 - platform: template
   sensors:
     wind_direction:

--- a/sensors.yaml
+++ b/sensors.yaml
@@ -58,7 +58,7 @@
     rain_today:
       value_template: >
         {%- if not (is_state("sensor.rain_amount","unknown") or is_state("sensor.rain_in_prior","unknown") )-%}
-        {{ ((states.sensor.rain_amount.state | float) - (states.sensor.rain_in_prior.state | float)) | max (0) | round(1) }}
+        {{ ((states.sensor.rain_amount.state | float) - (states.sensor.rain_in_prior.state | float)) | max (0) | round(2) }}
         {%- endif -%}
       friendly_name: "Rain Today"
       unit_of_measurement: "in"

--- a/sensors.yaml
+++ b/sensors.yaml
@@ -59,7 +59,7 @@
       value_template: >
         {%- if not (is_state("sensor.rain_amount","unknown") or is_state("sensor.rain_in_prior","unknown") )-%}
         {{ ((states.sensor.rain_amount.state | float) - (states.sensor.rain_in_prior.state | float)) | max (0) | round(1) }}
-        {%- endif -%}'
+        {%- endif -%}
       friendly_name: "Rain Today"
       unit_of_measurement: "in"
 

--- a/sensors.yaml
+++ b/sensors.yaml
@@ -71,3 +71,4 @@
         {% set direction = ['N','NNE','NE','ENE','E','ESE','SE','SSE','S','SSW','SW','WSW','W','WNW','NW','NNW','N'] %}
         {% set degree = states('sensor.wind_bearing')|float %}
         {{ direction[((degree+11.25)/22.5)|int] }}
+      friendly_name: "Wind Direction"


### PR DESCRIPTION
With [inspiration from the HA forums](https://community.home-assistant.io/t/how-to-daily-rain-sensor-from-cumulative-sensor-using-mqtt-and-template-sensor/20243), show how much rain we've had each day since midnight.

The sensor on the roof keeps track of the amount of rain it's seen in its lifetime. That's useful, but I'd rather see how much rain I've had in a day. This pushes the value of that counter to a persistent MQTT topic shortly after midnight, and then uses that to show how much rain we've had since that last push.